### PR TITLE
Include current directory in ini file search

### DIFF
--- a/openitcockpit.py
+++ b/openitcockpit.py
@@ -47,7 +47,8 @@ class Configuration(object):
         cfg.add_section('openitcockpit')
         read = cfg.read(['/etc/ansible/openitcockpit.ini',
                          os.path.expanduser('~/.ansible/openitcockpit.ini'),
-                         'openitcockpit.ini'])
+                         'openitcockpit.ini',
+                         os.path.dirname(os.path.realpath(__file__)) + '/openitcockpit.ini' ])
         if len(read) < 1:
             exit_fail('Could not find any configuration file')
         self.url = cfg.get('openitcockpit', 'url')

--- a/openitcockpit.py
+++ b/openitcockpit.py
@@ -48,7 +48,7 @@ class Configuration(object):
         read = cfg.read(['/etc/ansible/openitcockpit.ini',
                          os.path.expanduser('~/.ansible/openitcockpit.ini'),
                          'openitcockpit.ini',
-                         os.path.dirname(os.path.realpath(__file__)) + '/openitcockpit.ini' ])
+                         os.path.join(os.path.dirname(os.path.realpath(__file__)), 'openitcockpit.ini')])
         if len(read) < 1:
             exit_fail('Could not find any configuration file')
         self.url = cfg.get('openitcockpit', 'url')


### PR DESCRIPTION
Include current directory when looking for ini file, this is useful when the script is in a directory and executed from the parent and the ini file is in the same directory as the script.